### PR TITLE
add a .tool-versions file for asdf users

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+ruby system


### PR DESCRIPTION
this is kind of a hack and probably we instead will need to get people using `asdf` to run `pre-commit` hooks _outside_ of asdf, but it at least moves things forward a little bit