### PR TITLE
chore: change asdf pin to ruby 2.7

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-ruby system
+ruby latest:2.7


### PR DESCRIPTION
This is specifically for people running Big Sur that still have a system-wide 2.6. I do not recommend using Big Sur any more.