### PR TITLE
chore: bump pre-commit-standardrb to 1.20.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,4 @@ repos:
         types: ["ruby"]
         verbose: true
         additional_dependencies:
-          - "standard:1.1.1"
+          - "standard:1.20.0"

--- a/pre_commit_fake_gem.gemspec
+++ b/pre_commit_fake_gem.gemspec
@@ -4,6 +4,6 @@ Gem::Specification.new do |s|
   s.authors = ["Jamie Alessio"]
   s.summary = "A fake gem for pre-commit-standardrb"
   s.description = "A fake gem for pre-commit-standardrb"
-  s.add_dependency "standard", "1.18.0"
+  s.add_dependency "standard", "1.20.0"
   s.required_ruby_version = ">= 2.7"
 end


### PR DESCRIPTION
will have to bump the pin for this pre-commit tool in sync with bumping the local version in the Gemfile of our various other repos