### PR TITLE
chore: bump pre-commit-standardrb to standard 1.21.1

### DIFF
--- a/pre_commit_fake_gem.gemspec
+++ b/pre_commit_fake_gem.gemspec
@@ -4,6 +4,6 @@ Gem::Specification.new do |s|
   s.authors = ["Jamie Alessio"]
   s.summary = "A fake gem for pre-commit-standardrb"
   s.description = "A fake gem for pre-commit-standardrb"
-  s.add_dependency "standard", "1.20.0"
+  s.add_dependency "standard", "1.21.1"
   s.required_ruby_version = ">= 2.7"
 end


### PR DESCRIPTION
1.21.1 is out with a bug fix for disable comments (see https://github.com/testdouble/standard/issues/497)
